### PR TITLE
Update af.ui.js

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -1043,10 +1043,12 @@
             //get first div, defer
 
             var first=$(".view[data-default='true']");
-            if(first.length===0)
+            if(first.length===0) {
                 first=$(".view").eq(0);
-            else
-                throw ("You need to create a view");
+                
+                if(first.length===0)
+                    throw ("You need to create a view");
+            }
 
             first.addClass("active");
             //history


### PR DESCRIPTION
I ran into an issue using AF3 where setting the default panel wouldn't set the default view, it would still use the first view encountered.

In my situation, if the user had previously selected a language, I needed the "main" panel to show.  In the below example the "splash" panel would be used. Using loadContent would cause the user to see a flicker or transition from "splash" to "main".

```
<div id="language_select" class="view">
    <div class="pages">
        <div id="splash" data-include="content/splash.html" class="panel"></div>
    </div>
</div>

<div id="mainview" class="view">
    <div class="pages">
        <div id="main" selected="true" data-include="content/main.html" class="panel"></div>
    </div>
</div>
```

I looked at the source of af.ui.js and came accross this bit of code:

```
var first=$(".view[data-default='true']");
if(first.length===0)
    first=$(".view").eq(0);
else
    throw ("You need to create a view");
```

But giving the appropriate view the "default" data attribute would cause first.length to equal 1, throwing the error.

I changed the code to the following, which I think was the original intention:

```
var first=$(".view[data-default='true']");
if(first.length===0) {
    first=$(".view").eq(0);

    if(first.length===0)
        throw ("You need to create a view");
}
```

Now in my code I can use something like this to show the appropriate initial panel.

```
if (language === null) {
    $("#language_select").attr("data-default", "true");
    $("#splash").attr("selected", "true");
}
else {
    $("#mainview").attr("data-default", "true");
    $("#main").attr("selected", "true");
}
```

Or give a view the "default" data attribute to a view that isn't the first one encountered.
